### PR TITLE
Improved error handling & fetch relationship hardening

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "redux-jsonapi",
   "description": "Redux reducer, actions, and serializers for JSON:API",
   "homepage": "https://github.com/andhite/redux-jsonapi#readme",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "main": "dist/index.js",
   "author": {
     "name": "Andrew Hite"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "redux-jsonapi",
   "description": "Redux reducer, actions, and serializers for JSON:API",
   "homepage": "https://github.com/andhite/redux-jsonapi#readme",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "main": "dist/index.js",
   "author": {
     "name": "Andrew Hite"

--- a/src/middleware/createApiMiddleware.js
+++ b/src/middleware/createApiMiddleware.js
@@ -69,13 +69,11 @@ function createMiddleware(host, defaultHeaders) {
       },
     });
 
-    if (response.ok) {
+    if (response.status === 204) {
+      return {resources};
+    } else if (response.ok) {
       return handleResponse(response);
     }
-
-        response = handleErrors(response);
-    response = response.status === 204 ? { resources } : handleResponse(response);
-
 
     const error = new Error(response.statusText);
     error.response = response;

--- a/src/middleware/createApiMiddleware.js
+++ b/src/middleware/createApiMiddleware.js
@@ -16,7 +16,7 @@ function serialize(resource) {
 function handleErrors(response) {
   if (!response.ok) {
     const error = new Error(response.statusText);
-    error.status = response.status;
+    error.response = response;
     throw error;
   }
 
@@ -65,10 +65,13 @@ function createMiddleware(host, defaultHeaders) {
       },
     });
 
-    response = handleErrors(response);
-    response = handleResponse(response);
+    if (response.ok) {
+      return handleResponse(response);
+    }
 
-    return response;
+     const error = new Error(response.statusText);
+      error.response = response;
+      throw error;
   };
 
   const requestActions = {

--- a/src/middleware/createApiMiddleware.js
+++ b/src/middleware/createApiMiddleware.js
@@ -14,13 +14,9 @@ function serialize(resource) {
 }
 
 function handleErrors(response) {
-  if (!response.ok) {
     const error = new Error(response.statusText);
     error.response = response;
     throw error;
-  }
-
-  return response;
 }
 
 async function handleResponse(response) {
@@ -69,15 +65,14 @@ function createMiddleware(host, defaultHeaders) {
       },
     });
 
-    if (response.status === 204) {
-      return {resources};
-    } else if (response.ok) {
+    if (response.ok) {
+      if (response.status === 204) {
+        return {resources};
+      }
       return handleResponse(response);
     }
+    handleErrors(response);
 
-    const error = new Error(response.statusText);
-    error.response = response;
-    throw error;
   };
 
   const requestActions = {

--- a/src/middleware/createApiMiddleware.js
+++ b/src/middleware/createApiMiddleware.js
@@ -73,9 +73,9 @@ function createMiddleware(host, defaultHeaders) {
       return handleResponse(response);
     }
 
-     const error = new Error(response.statusText);
-      error.response = response;
-      throw error;
+    const error = new Error(response.statusText);
+    error.response = response;
+    throw error;
   };
 
   const requestActions = {

--- a/src/middleware/createApiMiddleware.js
+++ b/src/middleware/createApiMiddleware.js
@@ -29,13 +29,15 @@ async function handleResponse(response) {
       resources: [...(Array.isArray(data) ? data : [data]), ...included],
       result: Array.isArray(data) ? data.map((r) => r.id) : data.id,
       meta,
+      status: response.status
     };
   }
 
   return {
     resources: [],
     result: null,
-    meta
+    meta,
+    status: response.status
   };
 }
 

--- a/src/middleware/createApiMiddleware.js
+++ b/src/middleware/createApiMiddleware.js
@@ -1,6 +1,8 @@
 import queryString from 'qs';
 import { decamelize } from 'humps';
 import * as apiActions from '../modules/api';
+import fetch from 'isomorphic-fetch'
+
 
 function getDefaultHeaders() {
   return {

--- a/src/modules/api.js
+++ b/src/modules/api.js
@@ -1,6 +1,7 @@
 import { camelize } from 'humps';
 import { serialize, deserialize } from '../serializers';
 
+export const FAIL = '@@redux-jsonapi/FAIL';
 export const RECEIVE = '@@redux-jsonapi/RECEIVE';
 export const GET = '@@redux-jsonapi/GET';
 export const POST = '@@redux-jsonapi/POST';
@@ -9,7 +10,7 @@ export const DELETE = '@@redux-jsonapi/DELETE';
 
 const request = (method, resources, { meta = {}, ...payload }) => {
   return {
-    type: method,
+    type:    method,
     payload: {
       ...payload,
       resources,
@@ -42,10 +43,22 @@ export const remove = (resources, payload = {}) => {
 
 export const receive = (resources, method) => {
   return {
-    type: RECEIVE,
+    type:    RECEIVE,
     payload: {
       method,
       resources
+    },
+  };
+};
+
+export const fail = (response, method) => {
+  const { statusText } = response;
+  return {
+    type:    FAIL,
+    payload: {
+      method,
+      response,
+      statusText,
     },
   };
 };
@@ -65,7 +78,7 @@ export const fetchRelationships = (resource, payload = {}) => {
                   return dispatch(read(relation, payload));
                 })
               );
-            } else if (relationship._meta && !relationship._meta.loaded){
+            } else if (relationship._meta && !relationship._meta.loaded) {
               return dispatch(read(relationship, payload));
             }
           }
@@ -79,12 +92,11 @@ export const fetchRelationships = (resource, payload = {}) => {
   };
 };
 
-
-function getInitialState() {
+function getInitialState () {
   return {};
 }
 
-function receiveReducer(state, { method, resources }) {
+function receiveReducer (state, { method, resources }) {
   return resources.reduce((nextState, resource) => {
     return {
       ...nextState,
@@ -96,8 +108,8 @@ function receiveReducer(state, { method, resources }) {
   }, state);
 }
 
-function reducer(state = getInitialState(), { type, payload }) {
-  switch(type) {
+function reducer (state = getInitialState(), { type, payload }) {
+  switch (type) {
     case RECEIVE:
       return receiveReducer(state, payload);
     default:

--- a/src/modules/api.js
+++ b/src/modules/api.js
@@ -58,7 +58,7 @@ export const fetchRelationships = (resource, payload = {}) => {
           const relationship = resource[key]();
 
           if (relationship) {
-            if (Array.isArray(relationship)) {
+            if (Array.isArray(relationship) && relationship.length) {
               return Promise.all(relationship.filter((relation) => {
                   return relation._meta && !relation._meta.loaded
                 }).map((relation) => {
@@ -70,9 +70,11 @@ export const fetchRelationships = (resource, payload = {}) => {
             }
           }
         }
+      }).filter((promise) => {
+        return promise != undefined;
       })
     ).then(() => {
-      return deserialize(getState().api[resource._type][resource.id], getState().api);
+      return deserialize(getState().api[camelize(resource._type)][resource.id], getState().api);
     });
   };
 };

--- a/src/modules/api.js
+++ b/src/modules/api.js
@@ -57,8 +57,17 @@ export const fetchRelationships = (resource, payload = {}) => {
         if (typeof resource[key] === 'function') {
           const relationship = resource[key]();
 
-          if (relationship && !relationship._meta.loaded) {
-            return dispatch(read(relationship, payload));
+          if (relationship) {
+            if (Array.isArray(relationship)) {
+              return Promise.all(relationship.filter((relation) => {
+                  return relation._meta && !relation._meta.loaded
+                }).map((relation) => {
+                  return dispatch(read(relation, payload));
+                })
+              );
+            } else if (relationship._meta && !relationship._meta.loaded){
+              return dispatch(read(relationship, payload));
+            }
           }
         }
       })

--- a/src/serializers/deserialize.js
+++ b/src/serializers/deserialize.js
@@ -7,6 +7,10 @@ function deserializeRelationships(resources = [], store) {
 }
 
 function deserializeRelationship(resource = {}, store) {
+  if (!resource) {
+    return null;
+  }
+
   if (store[camelize(resource.type)] && store[camelize(resource.type)][resource.id]) {
     return deserialize({ ...store[camelize(resource.type)][resource.id], meta: { loaded: true } }, store);
   }


### PR DESCRIPTION
## Error handling

Adds the response to the thrown error so the error object is readable when it's handled with promises (I need it to show the error for a specific form field)
## Fetch relationship

Fixes some basic issues with the structure of the method
- adds calls for array relationships
- uses `item._type` instead of `item.type`
- uses camelize on `item._type` before looking it up in the redux store
